### PR TITLE
Fix resource requirements.

### DIFF
--- a/kafka/50kafka.yml
+++ b/kafka/50kafka.yml
@@ -54,6 +54,8 @@ spec:
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
         - name: JMX_PORT
           value: "5555"
+        - name: KAFKA_HEAP_OPTS
+          value: -Xmx1g -Xms1g
         ports:
         - name: inside
           containerPort: 9092
@@ -70,13 +72,10 @@ spec:
              command: ["sh", "-ce", "kill -s TERM 1; while $(kill -0 1 2>/dev/null); do sleep 1; done"]
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 750m
+            memory: 1152Mi
           limits:
-            # This limit was intentionally set low as a reminder that
-            # the entire Yolean/kubernetes-kafka is meant to be tweaked
-            # before you run production workloads
-            memory: 600Mi
+            memory: 1280Mi
         readinessProbe:
           tcpSocket:
             port: 9092

--- a/zookeeper/50pzoo.yml
+++ b/zookeeper/50pzoo.yml
@@ -39,6 +39,8 @@ spec:
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
+        - name: KAFKA_HEAP_OPTS
+          value: -Xmx512m -Xms512m
         command:
         - ./bin/zookeeper-server-start.sh
         - /etc/kafka/zookeeper.properties
@@ -55,10 +57,10 @@ spec:
           name: leader-election
         resources:
           requests:
-            cpu: 10m
-            memory: 100Mi
+            cpu: 250m
+            memory: 576Mi
           limits:
-            memory: 120Mi
+            memory: 640Mi
         readinessProbe:
           exec:
             command:

--- a/zookeeper/51zoo.yml
+++ b/zookeeper/51zoo.yml
@@ -42,6 +42,8 @@ spec:
         env:
         - name: KAFKA_LOG4J_OPTS
           value: -Dlog4j.configuration=file:/etc/kafka/log4j.properties
+        - name: KAFKA_HEAP_OPTS
+          value: -Xmx512m -Xms512m
         command:
         - ./bin/zookeeper-server-start.sh
         - /etc/kafka/zookeeper.properties
@@ -58,10 +60,10 @@ spec:
           name: leader-election
         resources:
           requests:
-            cpu: 10m
-            memory: 100Mi
+            cpu: 250m
+            memory: 576Mi
           limits:
-            memory: 120Mi
+            memory: 640Mi
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
Memory limits are based off of inspecting the default java opts used in the startup scripts.